### PR TITLE
dbt-core v1.11.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - python >=3.10
     - pip
+    - hatchling
   run:
     - python >=3.10
     - agate >=1.7.0,<1.10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dbt-core" %}
-{% set version = "1.9.1" %}
+{% set version = "1.11.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_core-{{ version }}.tar.gz
-  sha256: 38c931dd5206fdb11a9db1decf1075ce891ad9f4692bd00a9ba760a6cfe4358d
+  sha256: e53cfccc8c9c13a082e518bf80cf3bb33c2f1fdc3cab48ec822ef93737eccb81
 
 build:
   entry_points:
@@ -18,28 +18,31 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
   run:
-    - python >=3.9
+    - python >=3.10
     - agate >=1.7.0,<1.10
-    - jinja2 >=3.1.3,<4
-    - mashumaro >=3.9,<3.15
-    - click >=8.0.2,<9.0
-    - networkx >=2.3,<4.0
-    - protobuf >=5.0,<6.0
-    - requests <3.0.0
-    - snowplow-tracker >=1.0.2,<2.0
-    - pathspec >=0.9,<0.13
-    - sqlparse >=0.5.0,<0.6.0
+    - click >=8.3.0,<9.0
+    - daff >=1.3.46
+    - dbt-adapters >=1.15.5,<2.0
+    - dbt-common >=1.37.3,<2.0
     - dbt-extractor >=0.5.0,<=0.6
-    - dbt-semantic-interfaces >=0.7.4,<0.8
-    - dbt-common >=1.13.0,<2.0
-    - dbt-adapters >=1.10.1,<2.0
+    - dbt-protos >=1.0.405,<2.0
+    - dbt-semantic-interfaces >=0.9.0,<0.10
+    - jinja2 >=3.1.3,<4
+    - jsonschema >=4.19.1,<5.0
+    - mashumaro >=3.9,<3.15
+    - networkx >=2.3,<4.0
     - packaging >20.9
+    - pathspec >=0.9,<0.13
+    - protobuf >=6.0,<7.0
+    - pydantic <3
     - pytz >=2015.7
     - pyyaml >=6.0
-    - daff >=1.3.46
+    - requests <3.0.0
+    - snowplow-tracker >=1.0.2,<2.0
+    - sqlparse >=0.5.5,<0.6.0
     - typing-extensions >=4.4
 
 test:
@@ -55,7 +58,7 @@ about:
   home: https://github.com/dbt-labs/dbt-core
   summary: With dbt, data analysts and engineers can build analytics the way engineers build applications.
   license: Apache-2.0
-  license_file: License.md
+  license_file: LICENSE
 
 extra:
   anaconda-services:


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15857
- Dev URL: https://github.com/dbt-labs/dbt-core/tree/v1.11.11
- PyPI: https://pypi.org/project/dbt-core/1.11.11
- PyPI Inspector: https://inspector.pypi.io/project/dbt-core/1.11.11

## Changes
- Version bump 1.9.1 → 1.11.11
- python: >=3.9 → >=3.10
- click: >=8.0.2 → >=8.3.0
- protobuf: >=5.0,<6.0 → >=6.0,<7.0
- sqlparse: >=0.5.0 → >=0.5.5
- dbt-semantic-interfaces: >=0.7.4,<0.8 → >=0.9.0,<0.10
- dbt-common: >=1.13.0 → >=1.37.3
- dbt-adapters: >=1.10.1 → >=1.15.5
- Added: jsonschema >=4.19.1,<5.0, dbt-protos >=1.0.405,<2.0, pydantic <3
- license_file: License.md → LICENSE

## Notes
- ~~dbt-common >=1.37.3 not yet in main (closest: 1.28.0) — separate PKG ticket needed~~